### PR TITLE
Imageregexp admission controller

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -19,7 +19,7 @@ steps:
         cd cluster/images/hyperkube
         export REGISTRY=docker.hubteam.com/kubernetes
         export ARCH=amd64
-        export VERSION=$KUBE_VERSION-hs-$MODULE_BUILD_NUMBER
+        export VERSION=$KUBE_VERSION-hs-imageregexp-$MODULE_BUILD_NUMBER
         export IMAGE_NAME=hyperkube-${ARCH}
         make build VERSION=${VERSION} ARCH=${ARCH}
         docker push ${REGISTRY}/${IMAGE_NAME}:${VERSION}

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -19,7 +19,7 @@ steps:
         cd cluster/images/hyperkube
         export REGISTRY=docker.hubteam.com/kubernetes
         export ARCH=amd64
-        export VERSION=$KUBE_VERSION-hs-imageregexp-$MODULE_BUILD_NUMBER
+        export VERSION=$KUBE_VERSION-$GIT_BRANCH-$MODULE_BUILD_NUMBER
         export IMAGE_NAME=hyperkube-${ARCH}
         make build VERSION=${VERSION} ARCH=${ARCH}
         docker push ${REGISTRY}/${IMAGE_NAME}:${VERSION}

--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -45,4 +45,5 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/storageclass/default"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/imageregexp"
 )

--- a/plugin/pkg/admission/imageregexp/admission.go
+++ b/plugin/pkg/admission/imageregexp/admission.go
@@ -73,17 +73,20 @@ func NewImageRegexp(config io.Reader) (admission.Interface, error) {
 
 	// compile the regexp(s), bail early if compilation fails
 	for i := range ac.ImageRegexpConfigs {
-		item := ac.ImageRegexpConfigs[i]
+		configItem := ac.ImageRegexpConfigs[i]
 
-		regexp, err := regexp.Compile(item.Regexp)
+		regexp, err := regexp.Compile(configItem.Regexp)
 
 		if err != nil {
 			return nil, err
 		}
 
-		glog.V(2).Infof("Compiled ImageRegexpConfig %s", item)
+		glog.V(2).Infof("Compiled ImageRegexpConfig %s", configItem)
 
-		items = append(items, imageRegexReplacement{Regexp: regexp, Replacement: item.Replacement})
+		items[i] = imageRegexReplacement{
+			Regexp: regexp,
+			Replacement: configItem.Replacement,
+		}
 	}
 
 	return &imageRegexp{

--- a/plugin/pkg/admission/imageregexp/admission.go
+++ b/plugin/pkg/admission/imageregexp/admission.go
@@ -1,0 +1,93 @@
+package imageregexp
+
+import (
+	"io"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"regexp"
+
+	"github.com/golang/glog"
+)
+
+func init() {
+	admission.RegisterPlugin("ImageRegexp", func(config io.Reader) (admission.Interface, error) {
+		return NewImageRegexp(config)
+	})
+}
+
+type imageRegexReplacement struct {
+	Regexp      *regexp.Regexp
+	Replacement string
+}
+
+type imageRegexp struct {
+	*admission.Handler
+	Items []imageRegexReplacement
+}
+
+func (ir *imageRegexp) handleContainer(container *api.Container) {
+	for i := range ir.Items {
+		container.Image = ir.Items[i].Regexp.ReplaceAllString(container.Image, ir.Items[i].Replacement)
+	}
+}
+
+func (ir *imageRegexp) Admit(attributes admission.Attributes) (err error) {
+	// bail early if no replacements
+	if len(ir.Items) == 0 {
+		return nil
+	}
+
+	// Ignore all calls to subresources or resources other than pods.
+	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != api.Resource("pods") {
+		return nil
+	}
+	pod, ok := attributes.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+
+	for i := range pod.Spec.InitContainers {
+		ir.handleContainer(&pod.Spec.InitContainers[i])
+	}
+
+	for i := range pod.Spec.Containers {
+		ir.handleContainer(&pod.Spec.Containers[i])
+	}
+
+	return nil
+}
+
+func NewImageRegexp(config io.Reader) (admission.Interface, error) {
+	var ac AdmissionConfig
+	d := yaml.NewYAMLOrJSONDecoder(config, 4096)
+	err := d.Decode(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]imageRegexReplacement, len(ac.ImageRegexpConfigs))
+
+	// compile the regexp(s), bail early if compilation fails
+	for i := range ac.ImageRegexpConfigs {
+		item := ac.ImageRegexpConfigs[i]
+
+		regexp, err := regexp.Compile(item.Regexp)
+
+		if err != nil {
+			return nil, err
+		}
+
+		glog.V(2).Infof("Compiled ImageRegexpConfig %s", item)
+
+		items = append(items, imageRegexReplacement{Regexp: regexp, Replacement: item.Replacement})
+	}
+
+	return &imageRegexp{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+		Items:   items,
+	}, nil
+}

--- a/plugin/pkg/admission/imageregexp/admission.go
+++ b/plugin/pkg/admission/imageregexp/admission.go
@@ -64,7 +64,7 @@ func (ir *imageRegexp) Admit(attributes admission.Attributes) (err error) {
 func NewImageRegexp(config io.Reader) (admission.Interface, error) {
 	var ac AdmissionConfig
 	d := yaml.NewYAMLOrJSONDecoder(config, 4096)
-	err := d.Decode(&config)
+	err := d.Decode(&ac)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/imageregexp/admission.go
+++ b/plugin/pkg/admission/imageregexp/admission.go
@@ -15,7 +15,11 @@ import (
 
 func init() {
 	admission.RegisterPlugin("ImageRegexp", func(config io.Reader) (admission.Interface, error) {
-		return NewImageRegexp(config)
+		newImageRegexp, err := NewImageRegexp(config)
+		if err != nil {
+			return nil, err
+		}
+		return newImageRegexp, nil
 	})
 }
 

--- a/plugin/pkg/admission/imageregexp/admission.go
+++ b/plugin/pkg/admission/imageregexp/admission.go
@@ -34,8 +34,8 @@ type imageRegexp struct {
 }
 
 func (ir *imageRegexp) handleContainer(container *api.Container) {
-	for i := range ir.Items {
-		container.Image = ir.Items[i].Regexp.ReplaceAllString(container.Image, ir.Items[i].Replacement)
+	for _, irr := range ir.Items {
+		container.Image = irr.Regexp.ReplaceAllString(container.Image, irr.Replacement)
 	}
 }
 
@@ -54,12 +54,12 @@ func (ir *imageRegexp) Admit(attributes admission.Attributes) (err error) {
 		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
 
-	for i := range pod.Spec.InitContainers {
-		ir.handleContainer(&pod.Spec.InitContainers[i])
+	for _, initContainer := range pod.Spec.InitContainers {
+		ir.handleContainer(&initContainer)
 	}
 
-	for i := range pod.Spec.Containers {
-		ir.handleContainer(&pod.Spec.Containers[i])
+	for _, container := range pod.Spec.Containers {
+		ir.handleContainer(&container)
 	}
 
 	return nil
@@ -76,9 +76,7 @@ func NewImageRegexp(config io.Reader) (admission.Interface, error) {
 	items := make([]imageRegexReplacement, len(ac.ImageRegexpConfigs))
 
 	// compile the regexp(s), bail early if compilation fails
-	for i := range ac.ImageRegexpConfigs {
-		configItem := ac.ImageRegexpConfigs[i]
-
+	for i, configItem := range ac.ImageRegexpConfigs {
 		regexp, err := regexp.Compile(configItem.Regexp)
 
 		if err != nil {

--- a/plugin/pkg/admission/imageregexp/admission_test.go
+++ b/plugin/pkg/admission/imageregexp/admission_test.go
@@ -1,0 +1,73 @@
+package imageregexp
+
+import (
+	"testing"
+	"strings"
+
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+const ImageRegexpConfigYAML = `
+imageRegexp:
+- regexp: "^(.*?):deployed$"
+  replacement: "$1:deployed-test"
+`
+
+const ReplacementSuffix = ":deployed-test"
+
+func TestNewFromConfig(t *testing.T) {
+	ir, err := NewImageRegexp(strings.NewReader(ImageRegexpConfigYAML))
+
+	if err != nil {
+		t.Errorf("Failed to create new ImageRegexp from YAML: %s", err)
+		return
+	}
+
+	pod := &api.Pod{
+		Spec: api.PodSpec{
+			ServiceAccountName: "default",
+			SecurityContext:    &api.PodSecurityContext{},
+			InitContainers: []api.Container{
+				{
+					Image:           "testregistry.com:8080/user/image:deployed",
+				},
+				{
+					Image:			"testregistry.com:8080/user/image:latest",
+				},
+			},
+			Containers: []api.Container{
+				{
+					Image:           "testregistry.com:8080/user/image:deployed",
+				},
+				{
+					Image:			"testregistry.com:8080/user/image:latest",
+				},
+			},
+		},
+	}
+
+	attr := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), "namespace", "", api.Resource("pods").WithVersion("version"), "", admission.Create, &user.DefaultInfo{})
+
+	if err2 := ir.Admit(attr); err2 != nil {
+		t.Errorf("Failed to admit pod: %s", err)
+		return
+	}
+
+	if !strings.HasSuffix(pod.Spec.InitContainers[0].Image, ReplacementSuffix) {
+		t.Errorf("Image '%s' should have suffix '%s'", pod.Spec.Containers[0].Image, ReplacementSuffix)
+	}
+
+	if strings.HasSuffix(pod.Spec.InitContainers[1].Image, ReplacementSuffix) {
+		t.Errorf("Image '%s' should not have suffix '%s'", pod.Spec.Containers[1].Image, ReplacementSuffix)
+	}
+
+	if !strings.HasSuffix(pod.Spec.Containers[0].Image, ReplacementSuffix) {
+		t.Errorf("Image '%s' should have suffix '%s'", pod.Spec.Containers[0].Image, ReplacementSuffix)
+	}
+
+	if strings.HasSuffix(pod.Spec.Containers[1].Image, ReplacementSuffix) {
+		t.Errorf("Image '%s' should not have suffix '%s'", pod.Spec.Containers[1].Image, ReplacementSuffix)
+	}
+}

--- a/plugin/pkg/admission/imageregexp/admission_test.go
+++ b/plugin/pkg/admission/imageregexp/admission_test.go
@@ -9,11 +9,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-const ImageRegexpConfigYAML = `
-imageRegexp:
-- regexp: "^(.*?):deployed$"
-  replacement: "$1:deployed-test"
-`
+const ImageRegexpConfigYAML = `{"imageRegexp":[{"regexp":"^(.*?):deployed$","replacement":"$1:deployed-test"}]}`
 
 const ReplacementSuffix = ":deployed-test"
 

--- a/plugin/pkg/admission/imageregexp/config.go
+++ b/plugin/pkg/admission/imageregexp/config.go
@@ -1,0 +1,10 @@
+package imageregexp
+
+type imageRegexpConfig struct {
+	Regexp string `json:"regexp"`
+	Replacement   string `json:"replacement"`
+}
+
+type AdmissionConfig struct {
+	ImageRegexpConfigs []imageRegexpConfig `json:"imageRegexp"`
+}


### PR DESCRIPTION
This admission controller allows you to mutate container and init-container docker images via regex(es).