### PR TITLE
allow disabling kubernetes service registration

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -70,6 +70,7 @@ type ServerRunOptions struct {
 	ProxyClientKeyFile  string
 
 	EnableAggregatorRouting bool
+	SkipKubernetesService bool
 }
 
 // NewServerRunOptions creates a new ServerRunOptions object with default parameters
@@ -160,6 +161,9 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.IntVar(&s.MasterCount, "apiserver-count", s.MasterCount,
 		"The number of apiservers running in the cluster, must be a positive number.")
+
+	fs.BoolVar(&s.SkipKubernetesService, "skip-kubernetes-service", s.SkipKubernetesService,
+	"Skip registering this apiserver as part of the kubernetes service")
 
 	// See #14282 for details on how to test/try this option out.
 	// TODO: remove this comment once this option is tested in CI.

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -321,6 +321,7 @@ func CreateKubeAPIServerConfig(s *options.ServerRunOptions, nodeTunneler tunnele
 		KubernetesServiceNodePort: s.KubernetesServiceNodePort,
 
 		MasterCount: s.MasterCount,
+		SkipKubernetesService: s.SkipKubernetesService,
 	}
 
 	if nodeTunneler != nil {

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -133,6 +133,8 @@ type Config struct {
 	// Number of masters running; all masters must be started with the
 	// same value for this field. (Numbers > 1 currently untested.)
 	MasterCount int
+
+	SkipKubernetesService bool
 }
 
 // EndpointReconcilerConfig holds the endpoint reconciler and endpoint reconciliation interval to be


### PR DESCRIPTION
Adds `--skip-kubernetes-service` arg to kube-apiserver, which allows you to skip the `kubernetes` service registration at start.